### PR TITLE
rename config to esriConfig

### DIFF
--- a/src/clusterfeaturelayer.js
+++ b/src/clusterfeaturelayer.js
@@ -36,7 +36,7 @@ define([
 ], function (
     declare, arrayUtils, lang, Color, connect, on, all,
     SpatialReference, Point, Multipoint, Extent, Graphic,
-    config, normalizeUtils,
+    esriConfig, normalizeUtils,
     SimpleMarkerSymbol, SimpleLineSymbol, SimpleFillSymbol, TextSymbol, Font,
     ClassBreaksRenderer,
     esriRequest, symbolJsonUtils, rendererJsonUtil,


### PR DESCRIPTION
you require `config` but use `esriConfig` in the code. 