### PR TITLE
normalized map extent checks

### DIFF
--- a/src/clusterfeaturelayer.js
+++ b/src/clusterfeaturelayer.js
@@ -9,6 +9,7 @@ define([
 
     'esri/SpatialReference',
     'esri/geometry/Point',
+    'esri/geometry/Polygon',
     'esri/geometry/Multipoint',
     'esri/geometry/Extent',
     'esri/graphic',
@@ -35,7 +36,7 @@ define([
 
 ], function (
     declare, arrayUtils, lang, Color, connect, on, all,
-    SpatialReference, Point, Multipoint, Extent, Graphic,
+    SpatialReference, Point, Polygon, Multipoint, Extent, Graphic,
     esriConfig, normalizeUtils,
     SimpleMarkerSymbol, SimpleLineSymbol, SimpleFillSymbol, TextSymbol, Font,
     ClassBreaksRenderer,
@@ -503,7 +504,7 @@ define([
             //var start = new Date().valueOf();
             //console.debug('#inExtent start');
             
-            var ext = this._map.extent;
+            var ext = this._getNormalizedExtentsPolygon();
             var len = this._objectIdCache.length;
             var valid = [];
 
@@ -701,12 +702,15 @@ define([
             // Remove all existing graphics from layer
             this.clear();
 
+            // test against a modified/scrubbed map extent polygon geometry
+            var testExtent = this._getNormalizedExtentsPolygon();
+
             // first time through, loop through the points
             for ( var j = 0, jl = this._clusterData.length; j < jl; j++ ) {
                 // see if the current feature should be added to a cluster
                 var point = this._clusterData[j].geometry || this._clusterData[j];
                 // TEST - Only cluster what's in the current extent.  TODO - better way to do this?
-                if (!this._map.extent.contains(point)) {
+                if (!testExtent.contains(point)) {
                     // Reset all other clusters and make sure their id is changed
                     this._clusterData[j].attributes.clusterId = -1;
                     continue;
@@ -950,6 +954,21 @@ define([
             } else {
                 console.log('didn not find exactly one label: ', label);
             }
+        },
+
+        _getNormalizedExtentsPolygon: function() {
+            // normalize map extent and deal with up to 2 Extent geom objects,
+            // convert to Polygon geom objects,
+            // and combine into a master Polygon geom object to test against
+            var normalizedExtents = this._map.extent.normalize();
+            var normalizedExtentPolygons = arrayUtils.map(normalizedExtents, function(extent) {
+                return Polygon.fromExtent(extent);
+            });
+            var masterPolygon = new Polygon(this._map.spatialReference);
+            arrayUtils.forEach(normalizedExtentPolygons, function(polygon) {
+                masterPolygon.addRing(polygon.rings[0]);
+            });
+            return masterPolygon;
         },
 
         // debug only...never called by the layer


### PR DESCRIPTION
Clusters do not seem to draw beyond +/-180 longitude.  Wherever there are point-in-extent tests, I've introduced some Extent geom normalizing, and then test against a Polygon geom with up to 2 rings (instead of unioned Extent geoms).  Hopefully this resolves #16.

However, I'm not sure if the +/-180 long line will allow for nearby features on either side to properly cluster together; I'm concerned that it _might_ act like a wall separating 2 sides.  Thoughts?